### PR TITLE
Support DialContext for request

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	nurl "net/url"
 	"strings"
@@ -52,6 +53,7 @@ type Archiver struct {
 	RequestTimeout        time.Duration
 	SkipTLSVerification   bool
 	MaxConcurrentDownload int64
+	DialContext           func(ctx context.Context, network, addr string) (net.Conn, error)
 
 	isValidated bool
 	cookies     []*http.Cookie
@@ -80,6 +82,7 @@ func (arc *Archiver) Validate() {
 	arc.httpClient = &http.Client{
 		Timeout: arc.RequestTimeout,
 		Transport: &http.Transport{
+			DialContext: arc.DialContext,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: arc.SkipTLSVerification,
 			},


### PR DESCRIPTION
Thank you for the open-source obelisk.

When I imported obelisk to use it, I found it doesn't support DialContext, thus adding a new DialContext feature. The new DialContext supported is designed to be used as a proxy to preserve privacy and security when saving the webpage.

Why not use a system environment proxy or similar that uses IP and port, such as $HTTP_PROXY?

One reason is I don't need the entire system to use the proxy, and the other I prefer to be able to call my program via the third-party Go package, such as https://github.com/cretz/bine/.

Please accept the pull request if you believe it is appropriate, thank you.