### PR TITLE
Update call to css.NewLexer to the new functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-shiori/obelisk
+module github.com/tmahlburg/obelisk
 
 go 1.14
 

--- a/process-css.go
+++ b/process-css.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/tdewolff/parse/v2/css"
+	"github.com/tdewolff/parse/v2"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -18,7 +19,7 @@ func (arc *Archiver) processCSS(ctx context.Context, input io.Reader, baseURL *n
 
 	// Scan CSS and find all URLs
 	urls := make(map[string]struct{})
-	lexer := css.NewLexer(input)
+	lexer := css.NewLexer(parse.NewInput(input))
 
 	for {
 		token, bt := lexer.Next()


### PR DESCRIPTION
Currently, the behaviour of this package is not compatible with tdewolff/parse, because the signature of css.NewLexer has been changed. This pull request uses the new signature by creating a new ```parse.Input``` using the ```input``` ```io.Reader```.

If you have any comments or questions, let me know.