### PR TITLE
Set source URL into head meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Flags:
   -z, --gzip                          gzip archival result
   -h, --help                          help for obelisk
   -i, --input string                  path to file which contains URLs
+      --insecure                      skip X.509 (TLS) certificate verification
   -c, --load-cookies string           path to Netscape cookie file
       --max-concurrent-download int   max concurrent download at a time (default 10)
       --no-css                        disable CSS styling
@@ -67,6 +68,8 @@ Flags:
       --no-medias                     remove media elements (e.g img, audio)
   -o, --output string                 path to save archival result
   -q, --quiet                         disable logging
+      --skip-resource-url-error       skip process resource url error
+  -t, --timeout int                   maximum time (in second) before request timeout (default 60)
   -u, --user-agent string             set custom user agent
       --verbose                       more verbose logging
 ```

--- a/process-html.go
+++ b/process-html.go
@@ -30,6 +30,7 @@ func (arc *Archiver) processHTML(ctx context.Context, input io.Reader, baseURL *
 
 	// Prepare documents by doing these steps :
 	// - Set Content-Security-Policy to make sure no unwanted request happened
+	// - Set source URL into head
 	// - Apply configuration to documents
 	// - Replace all noscript to divs, to make it processed as well
 	// - Remove all comments in documents
@@ -37,6 +38,7 @@ func (arc *Archiver) processHTML(ctx context.Context, input io.Reader, baseURL *
 	// - Convert relative URL into absolute URL
 	// - Remove subresources integrity attribute from links
 	arc.setContentSecurityPolicy(doc)
+	arc.setSourceURL(doc, baseURL)
 	arc.applyConfiguration(doc)
 	arc.convertNoScriptToDiv(doc, true)
 	arc.removeComments(doc)
@@ -162,6 +164,16 @@ func (arc *Archiver) setContentSecurityPolicy(doc *html.Node) {
 		dom.SetAttribute(meta, "content", policies[i])
 		dom.PrependChild(heads[0], meta)
 	}
+}
+
+// set original URL into head meta
+func (arc *Archiver) setSourceURL(doc *html.Node, baseURL *nurl.URL) {
+	// Put the URL to head
+	heads := dom.GetElementsByTagName(doc, "head")
+	meta := dom.CreateElement("meta")
+	dom.SetAttribute(meta, "property", "source:url")
+	dom.SetAttribute(meta, "content", baseURL.String())
+	dom.PrependChild(heads[0], meta)
 }
 
 // applyConfiguration removes or replace elements following the configuration.


### PR DESCRIPTION
Hi @RadhiFadlillah,

Currently, it is not easy to find the source URL from the saved file, so I added a snippet to prepend the source link into head meta. It will be insert at the stages of document preparation, the format is `<meta property="source:url" content="https://www.example.org"/>`.