### PR TITLE
Fix `--load-cookies` not works

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -25,8 +25,10 @@ var (
 
 // Request is data of archival request.
 type Request struct {
-	Input   io.Reader
-	URL     string
+	Input io.Reader
+	URL   string
+
+	// Deprecated: Use `Archiver.WithCookies` instead.
 	Cookies []*http.Cookie
 
 	origin *nurl.URL // The original URL request was based from the input. If there are no redirects, it should be the same as `URL`.
@@ -145,6 +147,12 @@ func (arc *Archiver) Archive(ctx context.Context, req Request) ([]byte, string, 
 	}
 
 	return s2b(result), contentType, nil
+}
+
+// WithCookies attach request cookies to `Archiver`.
+func (arc *Archiver) WithCookies(cookies []*http.Cookie) *Archiver {
+	arc.cookies = cookies
+	return arc
 }
 
 // finalURI returns the final URL that has been redirected to another URL.

--- a/cmd/obelisk/main.go
+++ b/cmd/obelisk/main.go
@@ -192,7 +192,7 @@ func cmdHandler(cmd *cobra.Command, args []string) error {
 			}
 
 			req := obelisk.Request{
-				URL:     url.String(),
+				URL: url.String(),
 			}
 
 			// Start archival

--- a/cmd/obelisk/main.go
+++ b/cmd/obelisk/main.go
@@ -201,7 +201,7 @@ func cmdHandler(cmd *cobra.Command, args []string) error {
 				logrus.Printf("archival started for %s\n", request.URL)
 			}
 
-			result, contentType, err := archiver.Archive(context.Background(), req)
+			result, contentType, err := archiver.WithCookies(reqCookies).Archive(context.Background(), req)
 			if err != nil {
 				return err
 			}

--- a/cmd/obelisk/main.go
+++ b/cmd/obelisk/main.go
@@ -193,7 +193,6 @@ func cmdHandler(cmd *cobra.Command, args []string) error {
 
 			req := obelisk.Request{
 				URL:     url.String(),
-				Cookies: reqCookies,
 			}
 
 			// Start archival

--- a/process-html.go
+++ b/process-html.go
@@ -314,6 +314,7 @@ func (arc *Archiver) convertNoScriptToDiv(doc *html.Node, markNewDiv bool) {
 // convertLazyImageAttrs convert attributes data-src and data-srcset
 // which often found in lazy-loaded images and pictures, into basic attribute
 // src and srcset, so images that can be loaded without JS.
+//
 //nolint:gocyclo,goconst
 func (arc *Archiver) convertLazyImageAttrs(doc *html.Node) {
 	imageNodes := dom.GetAllNodesWithTag(doc, "img", "picture", "figure")


### PR DESCRIPTION
`Cookies` in `Request` does not work, so it is documented as deprecated, and adding the `WithCookies` method to attach cookies to `Archiver.cookies` may be a more reasonable solution, if you have a better way, please share it.

Fix #8 