### PR TITLE
Convert content of reader to UTF-8 before issuing processHTML

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -3,6 +3,7 @@ package obelisk
 import (
 	"context"
 	"fmt"
+	"golang.org/x/net/html/charset"
 	"io"
 	"net/http"
 	nurl "net/url"
@@ -139,8 +140,14 @@ func (arc *Archiver) Archive(ctx context.Context, req Request) ([]byte, string, 
 		return content, contentType, err
 	}
 
+	// Convert input to UTF-8
+	r, err := charset.NewReader(req.Input, contentType)
+	if err != nil {
+		r = req.Input
+	}
+
 	// If it's HTML process it
-	result, err := arc.processHTML(ctx, req.Input, url, false)
+	result, err := arc.processHTML(ctx, r, url, false)
 	if err != nil {
 		return nil, "", err
 	}

--- a/archiver.go
+++ b/archiver.go
@@ -3,7 +3,6 @@ package obelisk
 import (
 	"context"
 	"fmt"
-	"golang.org/x/net/html/charset"
 	"io"
 	"net/http"
 	nurl "net/url"
@@ -12,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/net/html/charset"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/kennygrant/sanitize"
@@ -144,6 +145,7 @@ func (arc *Archiver) Archive(ctx context.Context, req Request) ([]byte, string, 
 	r, err := charset.NewReader(req.Input, contentType)
 	if err != nil {
 		r = req.Input
+		arc.logDebug(fmt.Sprintf("charset not supported: %s", contentType))
 	}
 
 	// If it's HTML process it

--- a/log.go
+++ b/log.go
@@ -19,3 +19,10 @@ func (arc *Archiver) logURL(url, parentURL string, isCached bool) {
 
 	logrus.WithFields(fields).Println(url)
 }
+
+func (arc *Archiver) logDebug(msg string) {
+	if !arc.EnableLog {
+		return
+	}
+	logrus.Debug(msg)
+}


### PR DESCRIPTION
When trying to archive a page with Windows-1251 charset, title is messed up.
See screenshot: 
<img width="326" alt="image" src="https://github.com/user-attachments/assets/7f909faa-1532-49c7-b8c9-9a25af373273" />
Link to test against: http://vol2-2016.ecpp-journal.ru/1030.html